### PR TITLE
Add Happy Friday Eve

### DIFF
--- a/data/rss.json
+++ b/data/rss.json
@@ -314,6 +314,11 @@
     "twitter": "@exportfm",
     "hashtag": "#exportfm"
   },
+  "happyfridayeve": {
+    "feed": "https://feeds.soundcloud.com/users/soundcloud:users:770494357/sounds.rss",
+    "twitter": "@happyfriday_eve",
+    "hashtag": "#ハピフライブ"
+  },
   "hbSAKABA": {
     "feed": "https://heartbeats.jp/hbsakaba/rss",
     "twitter": "@heartbeatsjp",


### PR DESCRIPTION
Happy Friday Eve
https://soundcloud.com/happyfridayeve

内容はあまりテック系ではありませんが、プログラマが配信しているPodcastです。
趣旨に反していなければ追加していただきたいです。よろしくお願いいたします。