### PR TITLE
add accessibility to inactive

### DIFF
--- a/data/rss-inactive.json
+++ b/data/rss-inactive.json
@@ -1,4 +1,10 @@
 {
+  "accessibility": {
+    "feed": "https://accessibility.mitsue.co.jp/rss2.rss",
+    "twitter": null,
+    "hashtag": null,
+    "reason": "feed not found"
+  },
   "anitech": {
     "feed": "https://anitech.fm/feed/",
     "twitter": "@anitechfm",


### PR DESCRIPTION
Podcastのページは生きているのですがRSSは404になったので
https://accessibility.mitsue.co.jp/archives/podcast/