### PR TITLE
Update yuru28 feed url

### DIFF
--- a/data/rss.json
+++ b/data/rss.json
@@ -945,7 +945,7 @@
     "hashtag": "#ゆうかねラジオ"
   },
   "yuru28": {
-    "feed": "https://feeds.soundcloud.com/users/soundcloud:users:637230513/sounds.rss",
+    "feed": "https://yuru28.com/feed",
     "twitter": "@yuru28club",
     "hashtag": "#yuru28"
   },


### PR DESCRIPTION
はじめまして！[ゆるふわPodcast](https://yuru28.com)の @mktakuya です。
Podcast Freaksに私達のPodcastを掲載して頂きありがとうございます！

PodcastのフィードのURLですが、SoundCloudが発行しているものではなく自前で生成しているものを使っているので、更新のPull Requestを作成しました。
自前生成のフィードでは、各エピソードの `<link>` がSoundCloudのURLではなく、 `https://yuru28.com/${no}` のようなURLになっています。

ご確認よろしくお願いします 🙇‍♂️ 