### PR TITLE
Remove duplicate feed

### DIFF
--- a/data/rss.json
+++ b/data/rss.json
@@ -149,11 +149,6 @@
     "twitter": "@tchikuba",
     "hashtag": "#ceofm"
   },
-  "ceo-fm": {
-    "feed": "https://anchor.fm/s/13047d98/podcast/rss",
-    "twitter": null,
-    "hashtag": null
-  },
   "clfreaks": {
     "feed": "https://clfreaks.org/rss",
     "twitter": null,

--- a/data/rss.json
+++ b/data/rss.json
@@ -964,11 +964,6 @@
     "twitter": null,
     "hashtag": "#wadafm"
   },
-  "wakateossan": {
-    "feed": "https://wakateossan.github.io/feed.xml",
-    "twitter": null,
-    "hashtag": "#wakateossan"
-  },
   "wasabi": {
     "feed": "https://feeds.soundcloud.com/users/soundcloud:users:399843516/sounds.rss",
     "twitter": null,


### PR DESCRIPTION
- PR #128 had a duplicate feed of #113. Sorry.
- `https://wakateossan.github.io/` now redirects to `https://w2o.fm/`.