### PR TITLE
Fix build errors

### DIFF
--- a/data/rss-inactive.json
+++ b/data/rss-inactive.json
@@ -77,6 +77,12 @@
     "hashtag": "#railsdm",
     "reason": "feed not found"
   },
+  "rubyist-club": {
+    "feed": "https://rubyistclub.chezo.uno/feed.xml",
+    "twitter": null,
+    "hashtag": "#rubyistclub",
+    "reason": "feed not found"
+  },
   "secure-brigade": {
     "feed": "https://secure-brigade.com/podcast/index.xml",
     "twitter": null,

--- a/data/rss-inactive.json
+++ b/data/rss-inactive.json
@@ -17,6 +17,12 @@
     "hashtag": "#mook06",
     "reason": "end of broadcast"
   },
+  "facast": {
+    "feed": "https://facast.net/feed.xml",
+    "twitter": "@facast_net",
+    "hashtag": "#FAcast",
+    "reason": "website is closed"
+  },
   "genba": {
     "feed": "https://genba.fm/podcast.xml",
     "twitter": null,

--- a/data/rss-inactive.json
+++ b/data/rss-inactive.json
@@ -17,6 +17,12 @@
     "hashtag": "#mook06",
     "reason": "end of broadcast"
   },
+  "bdpfm": {
+    "feed": "https://bdpfm.jp/feed.xml",
+    "twitter": "@bdpfm",
+    "hashtag": "#bdpfm",
+    "reason": "domain revocation"
+  },
   "bitbitecoin": {
     "feed": "https://bitbitecoin.com/feed/?lang=ja",
     "twitter": "@bitbitecoin",

--- a/data/rss-inactive.json
+++ b/data/rss-inactive.json
@@ -100,5 +100,11 @@
     "twitter": null,
     "hashtag": "#wadafm",
     "reason": "feed not found"
+  },
+  "yabaihomepageyasan": {
+    "feed": "https://yabaihomepageyasan.com/feed/podcast/",
+    "twitter": null,
+    "hashtag": null,
+    "reason": "feed not found"
   }
 }

--- a/data/rss-inactive.json
+++ b/data/rss-inactive.json
@@ -107,6 +107,12 @@
     "hashtag": "#セキュア旅団",
     "reason": "domain revocation"
   },
+  "serverless-now": {
+    "feed": "https://serverless.fm/rss-feed/",
+    "twitter": null,
+    "hashtag": null,
+    "reason": "domain revocation"
+  },
   "shock-sheets-tech": {
     "feed": "https://feeds.feedburner.com/shock-sheets-tech",
     "twitter": null,

--- a/data/rss-inactive.json
+++ b/data/rss-inactive.json
@@ -94,5 +94,11 @@
     "twitter": null,
     "hashtag": null,
     "reason": "audio not found"
+  },
+  "wadafm": {
+    "feed": "https://feeds.soundcloud.com/users/soundcloud:users:134132881/sounds.rss",
+    "twitter": null,
+    "hashtag": "#wadafm",
+    "reason": "feed not found"
   }
 }

--- a/data/rss-inactive.json
+++ b/data/rss-inactive.json
@@ -17,6 +17,12 @@
     "hashtag": "#mook06",
     "reason": "end of broadcast"
   },
+  "bitbitecoin": {
+    "feed": "https://bitbitecoin.com/feed/?lang=ja",
+    "twitter": "@bitbitecoin",
+    "hashtag": null,
+    "reason": "website is closed"
+  },
   "facast": {
     "feed": "https://facast.net/feed.xml",
     "twitter": "@facast_net",

--- a/data/rss.json
+++ b/data/rss.json
@@ -129,11 +129,6 @@
     "twitter": "@basuke",
     "hashtag": "#basuke"
   },
-  "bdpfm": {
-    "feed": "https://bdpfm.jp/feed.xml",
-    "twitter": "@bdpfm",
-    "hashtag": "#bdpfm"
-  },
   "becochan": {
     "feed": "https://channel.becolomochi.com/feed.xml",
     "twitter": null,

--- a/data/rss.json
+++ b/data/rss.json
@@ -85,7 +85,7 @@
     "hashtag": "#aozorafm"
   },
   "ariel": {
-    "feed": "http://dev.ariel-networks.com/wp/archives/category/podcast/feed",
+    "feed": "https://dev.ariel-networks.com/wp/archives/category/podcast/feed",
     "twitter": null,
     "hashtag": null
   },

--- a/data/rss.json
+++ b/data/rss.json
@@ -139,11 +139,6 @@
     "twitter": null,
     "hashtag": "#becochan"
   },
-  "bitbitecoin": {
-    "feed": "https://bitbitecoin.com/feed/?lang=ja",
-    "twitter": "@bitbitecoin",
-    "hashtag": null
-  },
   "bitcoiners": {
     "feed": "https://anchor.fm/s/a8b554c/podcast/rss",
     "twitter": null,

--- a/data/rss.json
+++ b/data/rss.json
@@ -223,7 +223,7 @@
     "feed": "https://anchor.fm/s/603e2d70/podcast/rss",
     "twitter": null,
     "hashtag": null
-  },  
+  },
   "corklab": {
     "feed": "http://corklab.seesaa.net/index20.rdf",
     "twitter": null,
@@ -753,7 +753,7 @@
     "feed": "https://anchor.fm/s/67a9c1a0/podcast/rss",
     "twitter": "@normalizefm",
     "hashtag": "#normalizeFM"
-  },  
+  },
   "nounai": {
     "feed": "https://anchor.fm/s/46da39f0/podcast/rss",
     "twitter": null,

--- a/data/rss.json
+++ b/data/rss.json
@@ -205,7 +205,7 @@
     "hashtag": null
   },
   "codelunch-fm": {
-    "feed": "https://codelunch.fm/rss.xml",
+    "feed": "https://anchor.fm/s/77d9b6c/podcast/rss",
     "twitter": null,
     "hashtag": "#codelunchfm"
   },

--- a/data/rss.json
+++ b/data/rss.json
@@ -250,7 +250,7 @@
     "hashtag": null
   },
   "denkiya": {
-    "feed": "https://inst-web.com/denkiya_blog/feed",
+    "feed": "https://inst-web.com/feed",
     "twitter": "@_Coffee__",
     "hashtag": "#電器屋Walker"
   },

--- a/data/rss.json
+++ b/data/rss.json
@@ -1224,11 +1224,6 @@
     "twitter": "@Xtalk11",
     "hashtag": null
   },
-  "yabaihomepageyasan": {
-    "feed": "https://yabaihomepageyasan.com/feed/podcast/",
-    "twitter": null,
-    "hashtag": null
-  },
   "yancanfm": {
     "feed": "https://www.yancan.tech/feed.xml",
     "twitter": null,

--- a/data/rss.json
+++ b/data/rss.json
@@ -359,11 +359,6 @@
     "twitter": null,
     "hashtag": "#エスノエフエム"
   },
-  "facast": {
-    "feed": "https://facast.net/feed.xml",
-    "twitter": "@facast_net",
-    "hashtag": "#FAcast"
-  },
   "fan-tech": {
     "feed": "https://anchor.fm/s/11ba73c0/podcast/rss",
     "twitter": null,

--- a/data/rss.json
+++ b/data/rss.json
@@ -440,7 +440,7 @@
     "hashtag": "#httpradio"
   },
   "hbSAKABA": {
-    "feed": "https://heartbeats.jp/hbsakaba/rss",
+    "feed": "https://heartbeats.jp/hbsakaba/rss.xml",
     "twitter": "@heartbeatsjp",
     "hashtag": "#hbsakaba"
   },

--- a/data/rss.json
+++ b/data/rss.json
@@ -1179,11 +1179,6 @@
     "twitter": null,
     "hashtag": "#w2ofm"
   },
-  "wadafm": {
-    "feed": "https://feeds.soundcloud.com/users/soundcloud:users:134132881/sounds.rss",
-    "twitter": null,
-    "hashtag": "#wadafm"
-  },
   "wasabi": {
     "feed": "https://feeds.soundcloud.com/users/soundcloud:users:399843516/sounds.rss",
     "twitter": null,

--- a/data/rss.json
+++ b/data/rss.json
@@ -899,11 +899,6 @@
     "twitter": "@PitPa_jp",
     "hashtag": null
   },
-  "rubyist-club": {
-    "feed": "https://rubyistclub.chezo.uno/feed.xml",
-    "twitter": null,
-    "hashtag": "#rubyistclub"
-  },
   "sakura818uuu": {
     "feed": "https://anchor.fm/s/12fa96d4/podcast/rss",
     "twitter": null,

--- a/data/rss.json
+++ b/data/rss.json
@@ -1,6 +1,6 @@
 {
   "10xfm": {
-    "feed": "https://anchor.fm/10xfm",
+    "feed": "https://anchor.fm/s/559fd878/podcast/rss",
     "twitter": null,
     "hashtag": "#10xfm"
   },

--- a/data/rss.json
+++ b/data/rss.json
@@ -909,11 +909,6 @@
     "twitter": null,
     "hashtag": "#secure-brigade"
   },
-  "serverless-now": {
-    "feed": "https://serverless.fm/rss-feed/",
-    "twitter": null,
-    "hashtag": null
-  },
   "serverworksradio": {
     "feed": "https://anchor.fm/s/27ea43c8/podcast/rss",
     "twitter": null,

--- a/data/rss.json
+++ b/data/rss.json
@@ -1065,7 +1065,7 @@
     "hashtag": null
   },
   "the-startup-podcast": {
-    "feed": "https://podcast.no-new-folk.com/feed/",
+    "feed": "https://anchor.fm/s/4e5c1c48/podcast/rss",
     "twitter": null,
     "hashtag": null
   },


### PR DESCRIPTION
下記の13このbuild時のエラーへ対応した。

### 内訳

終わっている番組: 7
feedが変わっているもの: 6

### 気づき

- Anchorに移動する流れがみられる？
- netlifyで運営していてサイト自体がなくなったものは`Hostname/IP does not match certificate's altnames`というエラーになっていた

```
[error] wget | static/downloads/rss/ariel.rss | Error: protocol should be http or https
[error] xmlToJSON | static/downloads/rss/10xfm.rss
[error] wget | static/downloads/rss/codelunch-fm.rss | Server responded with unhandled status: 404
[error] wget | static/downloads/rss/facast.rss | Error [ERR_TLS_CERT_ALTNAME_INVALID]: Hostname/IP does not match certificate's altnames: Host: facast.net. is not in the cert's altnames: DNS:*.netlify.app, DNS:netlify.app
[error] wget | static/downloads/rss/denkiya.rss | Error: protocol should be http or https
[error] wget | static/downloads/rss/hbSAKABA.rss | Server responded with unhandled status: 404
[error] wget | static/downloads/rss/rubyist-club.rss | Server responded with unhandled status: 404
[error] wget | static/downloads/rss/serverless-now.rss | Error: getaddrinfo EAI_AGAIN serverless.fm
[error] wget | static/downloads/rss/bitbitecoin.rss | Error [ERR_TLS_CERT_ALTNAME_INVALID]: Hostname/IP does not match certificate's altnames: Host: bitbitecoin.com. is not in the cert's altnames: DNS:shortener.secureserver.net, DNS:www.shortener.secureserver.net
[error] wget | static/downloads/rss/wadafm.rss | Server responded with unhandled status: 404
[error] wget | static/downloads/rss/yabaihomepageyasan.rss | Server responded with unhandled status: 404
[error] xmlToJSON | static/downloads/rss/the-startup-podcast.rss
[error] wget | static/downloads/rss/bdpfm.rss | Error: connect ETIMEDOUT 150.95.255.38:443
```